### PR TITLE
refactor: remove imports to `watchonly`

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,8 @@
 import asyncio
+from typing import List
 
 from fastapi import APIRouter
 from fastapi.staticfiles import StaticFiles
-from typing import List
 
 from lnbits.db import Database
 from lnbits.helpers import template_renderer

--- a/models.py
+++ b/models.py
@@ -89,3 +89,11 @@ class SatsPayThemes(BaseModel):
     @classmethod
     def from_row(cls, row: Row) -> "SatsPayThemes":
         return cls(**dict(row))
+
+
+class WalletAccountConfig(BaseModel):
+    mempool_endpoint: str
+    receive_gap_limit: int
+    change_gap_limit: int
+    sats_denominated: bool
+    network: str


### PR DESCRIPTION
- `satspay` requires some data from `watchonly`
- get this data via the REST API instead of directly importing (`from ..watchonly.crud import`)