### PR TITLE
Use description as lightning invoice memo

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -31,7 +31,7 @@ async def create_charge(
         payment_hash, payment_request = await create_invoice(
             wallet_id=data.lnbitswallet,
             amount=data.amount,
-            memo=charge_id,
+            memo=data.description,
             extra={"tag": "charge"},
         )
     else:


### PR DESCRIPTION
For customers as well as merchant administration it makes more sense imo to use the self set description field instead of the charge id as the memo.