### PR TITLE
Hotfix LN tabs

### DIFF
--- a/templates/satspay/display.html
+++ b/templates/satspay/display.html
@@ -366,6 +366,8 @@
         this.loopPingWs()
         this.checkPendingOnchain()
         this.trackAddress(this.charge.onchainaddress)
+      } else {
+        this.tab = 'ln'
       }
     }
   })


### PR DESCRIPTION
When no onchain address was present, the tab would default to the BIP21 QR code.

Closes #30 