### PR TITLE
Fix lightning qr/copy value

### DIFF
--- a/templates/satspay/display.html
+++ b/templates/satspay/display.html
@@ -144,7 +144,7 @@
                 <satspay-show-qr
                   :charge-amount="charge.amount"
                   :type="'ln'"
-                  :value="'lightning:' + charge.payment_request.toUpperCase()"
+                  :value="charge.payment_request.toUpperCase()"
                   :href="'lightning:'+charge.payment_request"
                 ></satspay-show-qr>
               </div>


### PR DESCRIPTION
For example umbrell isn't handling the value of the QR and copy invoice button correctly due to the addition of 'lightning:'
Shouldn't be needed I think, since when a user scans the QR they will most likely do it with a wallet already. Same applices for the copy invoice, then they will paste it in their preferred wallet. 