### PR TITLE
fix: show BTC instead of sats for onchain

### DIFF
--- a/static/js/components.js
+++ b/static/js/components.js
@@ -62,7 +62,7 @@ Vue.component('satspay-show-qr', {
     </div>
   </div>`,
   computed: {
-    chargeAmountBtc(){
+    chargeAmountBtc() {
       return (this.chargeAmount / 1e8).toFixed(8)
     }
   }

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -38,8 +38,10 @@ Vue.component('satspay-show-qr', {
     <div class="row justify-center q-mb-sm">
       <div class="col text-center">
         <span v-if="type == 'btc'" class="text-subtitle2">Send
-          <span v-text="chargeAmount"></span>
-          sats to this onchain address</span>
+          <strong>
+          <span v-text="chargeAmountBtc"></span> BTC
+          </strong>
+           to this onchain address</span>
         <span v-if="type == 'ln'" class="text-subtitle2">Pay this lightning-network invoice:</span>
         <span v-if="type == 'uqr'" class="text-subtitle2">Scan QR with a wallet supporting BIP21:</span>
       </div>
@@ -58,7 +60,12 @@ Vue.component('satspay-show-qr', {
         <q-btn outline color="grey" @click="copyText(value)">Copy address</q-btn>
       </div>
     </div>
-  </div>`
+  </div>`,
+  computed: {
+    chargeAmountBtc(){
+      return (this.chargeAmount / 1e8).toFixed(8)
+    }
+  }
 })
 
 Vue.component('satspay-time-elapsed', {

--- a/templates/satspay/display.html
+++ b/templates/satspay/display.html
@@ -261,14 +261,13 @@
                 clearInterval(this.timerInterval)
 
                 // Check if redirection hasn't already occurred
-		        if (redirectToCompleteLink && this.charge.completelink) {
-                    redirectToCompleteLink = false;
-                    window.location.href = this.charge.completelink;
+                if (redirectToCompleteLink && this.charge.completelink) {
+                  redirectToCompleteLink = false
+                  window.location.href = this.charge.completelink
                 }
               }
-              this.timer += 0.25;
-            }
-              , 12.5)
+              this.timer += 0.25
+            }, 12.5)
           }
         } catch (error) {
           LNbits.utils.notifyApiError(error)


### PR DESCRIPTION
The oncain amout used to denominate in `sats` now it does it in `BTC`.

![image](https://github.com/user-attachments/assets/5bf83aec-01d4-404d-a2a8-637a5672429a)
