### PR TITLE
feat: make extra more versatile and use satspay config instead of onchainwallet config

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -23,7 +23,6 @@ async def create_charge(
     config: Optional[WalletAccountConfig] = None,
     onchainaddress: Optional[str] = None,
 ) -> Charge:
-    data = CreateCharge(**data.dict())
     charge_id = urlsafe_short_hash()
     if data.onchainwallet:
         if not onchainaddress or not config:

--- a/crud.py
+++ b/crud.py
@@ -1,4 +1,3 @@
-import json
 from typing import Optional
 
 from lnbits.core.services import create_invoice
@@ -11,7 +10,6 @@ from .models import (
     CreateSatsPayTheme,
     SatspaySettings,
     SatsPayTheme,
-    WalletAccountConfig,
 )
 
 db = Database("ext_satspay")
@@ -20,16 +18,12 @@ db = Database("ext_satspay")
 async def create_charge(
     user: str,
     data: CreateCharge,
-    config: Optional[WalletAccountConfig] = None,
     onchainaddress: Optional[str] = None,
 ) -> Charge:
     charge_id = urlsafe_short_hash()
     if data.onchainwallet:
-        if not onchainaddress or not config:
+        if not onchainaddress:
             raise Exception(f"Wallet '{data.onchainwallet}' can no longer be accessed.")
-        data.extra = json.dumps(
-            {"mempool_endpoint": config.mempool_endpoint, "network": config.network}
-        )
 
     assert data.amount, "Amount is required"
     if data.lnbitswallet:

--- a/helpers.py
+++ b/helpers.py
@@ -1,12 +1,10 @@
-import json
-
 import httpx
 from lnbits.core.crud import get_standalone_payment
 from lnbits.settings import settings
 from loguru import logger
 
 from .crud import get_or_create_satspay_settings
-from .models import Charge, OnchainBalance, WalletAccountConfig
+from .models import Charge, OnchainBalance
 
 
 async def call_webhook(charge: Charge):
@@ -48,7 +46,7 @@ async def fetch_onchain_balance(onchain_address: str) -> OnchainBalance:
         return OnchainBalance(confirmed=confirmed, unconfirmed=unconfirmed)
 
 
-async def fetch_onchain_config(api_key: str) -> WalletAccountConfig:
+async def fetch_onchain_config_network(api_key: str) -> str:
     async with httpx.AsyncClient() as client:
         headers = {"X-API-KEY": api_key}
         r = await client.get(
@@ -57,7 +55,7 @@ async def fetch_onchain_config(api_key: str) -> WalletAccountConfig:
         )
         r.raise_for_status()
         config = r.json()
-        return WalletAccountConfig.parse_obj(config)
+        return config["network"]
 
 
 async def fetch_onchain_address(wallet_id: str, api_key: str) -> str:

--- a/helpers.py
+++ b/helpers.py
@@ -105,7 +105,6 @@ async def check_charge_balance(charge: Charge) -> Charge:
 
     if charge.webhook:
         resp = await call_webhook(charge)
-        extra = json.loads(charge.extra) if charge.extra else {}
-        charge.extra = json.dumps({**extra, **resp})
+        charge.add_extra(resp)
 
     return charge

--- a/helpers.py
+++ b/helpers.py
@@ -48,10 +48,9 @@ async def fetch_onchain_balance(onchain_address: str) -> OnchainBalance:
 
 async def fetch_onchain_config_network(api_key: str) -> str:
     async with httpx.AsyncClient() as client:
-        headers = {"X-API-KEY": api_key}
         r = await client.get(
             url=f"http://{settings.host}:{settings.port}/watchonly/api/v1/config",
-            headers=headers,
+            headers={"X-API-KEY": api_key},
         )
         r.raise_for_status()
         config = r.json()
@@ -60,10 +59,9 @@ async def fetch_onchain_config_network(api_key: str) -> str:
 
 async def fetch_onchain_address(wallet_id: str, api_key: str) -> str:
     async with httpx.AsyncClient() as client:
-        headers = {"X-API-KEY": api_key}
         r = await client.get(
             url=f"http://{settings.host}:{settings.port}/watchonly/api/v1/address/{wallet_id}",
-            headers=headers,
+            headers={"X-API-KEY": api_key},
         )
         r.raise_for_status()
         address_data = r.json()

--- a/migrations.py
+++ b/migrations.py
@@ -175,3 +175,14 @@ async def m011_persist_paid(db):
         )
     except OperationalError:
         pass
+
+
+async def m012_add_setting_network(db):
+    """
+    Add 'network' column for storing the network
+    """
+    try:
+        await db.execute("ALTER TABLE satspay.settings ADD COLUMN network TEXT")
+        await db.execute("UPDATE satspay.settings SET network = 'Mainnet'")
+    except OperationalError:
+        pass

--- a/models.py
+++ b/models.py
@@ -28,18 +28,10 @@ class CreateCharge(BaseModel):
     time: int = Query(..., ge=1)
     amount: Optional[int] = Query(None, ge=1)
     zeroconf: bool = Query(False)
-    extra: str = DEFAULT_MEMPOOL_CONFIG
     custom_css: Optional[str] = Query(None)
     currency: str = Query(None)
     currency_amount: Optional[float] = Query(None)
-
-
-class ChargeConfig(BaseModel):
-    mempool_endpoint: str
-    network: Optional[str]
-    webhook_message: Optional[str]
-    webhook_success: bool = False
-    misc: dict = {}
+    extra: Optional[str] = Query(None)
 
 
 class Charge(BaseModel):
@@ -55,7 +47,6 @@ class Charge(BaseModel):
     completelink: Optional[str]
     completelinktext: Optional[str] = "Back to Merchant"
     custom_css: Optional[str]
-    extra: str = DEFAULT_MEMPOOL_CONFIG
     time: int
     amount: int
     zeroconf: bool
@@ -66,11 +57,11 @@ class Charge(BaseModel):
     currency: Optional[str] = None
     currency_amount: Optional[float] = None
     paid: bool = False
+    extra: Optional[str] = None
 
-    @property
-    def config(self) -> ChargeConfig:
-        charge_config = json.loads(self.extra)
-        return ChargeConfig(**charge_config)
+    def add_extra(self, extra: dict):
+        old_extra = json.loads(self.extra) if self.extra else {}
+        self.extra = json.dumps({**old_extra, **extra})
 
     @property
     def public(self):

--- a/models.py
+++ b/models.py
@@ -7,14 +7,10 @@ from typing import Optional
 from fastapi.param_functions import Query
 from pydantic import BaseModel
 
-DEFAULT_MEMPOOL_ENDPOINT = "https://mempool.space"
-DEFAULT_MEMPOOL_CONFIG = (
-    '{"mempool_endpoint": "https://mempool.space", "network": "Mainnet"}'
-)
-
 
 class SatspaySettings(BaseModel):
-    mempool_url: str = DEFAULT_MEMPOOL_ENDPOINT
+    mempool_url: str = "https://mempool.space"
+    network: str = "Mainnet"
 
 
 class CreateCharge(BaseModel):
@@ -99,14 +95,6 @@ class SatsPayTheme(BaseModel):
     title: str
     custom_css: str
     user: str
-
-
-class WalletAccountConfig(BaseModel):
-    mempool_endpoint: str
-    receive_gap_limit: int
-    change_gap_limit: int
-    sats_denominated: bool
-    network: str
 
 
 class OnchainBalance(BaseModel):

--- a/static/js/display.js
+++ b/static/js/display.js
@@ -5,7 +5,7 @@ new Vue({
   data() {
     return {
       charge: mapCharge(charge_data),
-      network: network,
+      mempool_url: mempool_url,
       ws: null,
       wallet: {
         inkey: ''
@@ -15,12 +15,9 @@ new Vue({
   },
   computed: {
     mempoolLink() {
-      const onchainaddress = this.charge.onchainaddress
-      if (this.network === 'Testnet') {
-        return `https://mempool.space/testnet/address/${onchainaddress}`
-      } else {
-        return `https://mempool.space/address/${onchainaddress}`
-      }
+      // remove trailing slash
+      const url = this.mempool_url.replace(/\/$/, '')
+      return `${url}/address/${this.charge.onchainaddress}`
     },
     unifiedQR() {
       const bitcoin = (this.charge.onchainaddress || '').toUpperCase()

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -10,7 +10,6 @@ new Vue({
     return {
       currencies: [],
       fiatRates: {},
-      settings: {},
       settings: [
         {
           type: 'str',

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -15,6 +15,12 @@ new Vue({
         {
           type: 'str',
           description:
+            'Network used by OnchainWallet extension Wallet. default: `Mainnet`, or `Testnet` for testnet',
+          name: 'network'
+        },
+        {
+          type: 'str',
+          description:
             'Mempool API URL. default: `https://mempool.space`, use `https://mempool.space/testnet` for testnet',
           name: 'mempool_url'
         }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -26,6 +26,7 @@ new Vue({
       ],
       filter: '',
       admin: admin,
+      network: network,
       balance: null,
       walletLinks: [],
       chargeLinks: [],
@@ -33,12 +34,7 @@ new Vue({
       themeOptions: [],
       onchainwallet: '',
       rescanning: false,
-      mempool: {
-        endpoint: '',
-        network: 'Mainnet'
-      },
       showAdvanced: false,
-
       chargesTable: {
         columns: [
           {
@@ -176,31 +172,16 @@ new Vue({
 
     getWalletLinks: async function () {
       try {
-        const {data} = await LNbits.api.request(
+        let {data} = await LNbits.api.request(
           'GET',
-          `/watchonly/api/v1/wallet?network=${this.mempool.network}`,
+          `/watchonly/api/v1/wallet?network=${this.network}`,
           this.g.user.wallets[0].adminkey
         )
+        data = data.filter(w => w.network === this.network)
         this.walletLinks = data.map(w => ({
           id: w.id,
           label: w.title + ' - ' + w.id
         }))
-      } catch (error) {
-        LNbits.utils.notifyApiError(error)
-      }
-    },
-
-    getWalletConfig: async function () {
-      try {
-        const {data} = await LNbits.api.request(
-          'GET',
-          '/watchonly/api/v1/config',
-          this.g.user.wallets[0].inkey
-        )
-        this.mempool.endpoint = data.mempool_endpoint
-        this.mempool.network = data.network || 'Mainnet'
-        const url = new URL(this.mempool.endpoint)
-        this.mempool.hostname = url.hostname
       } catch (error) {
         LNbits.utils.notifyApiError(error)
       }
@@ -431,7 +412,6 @@ new Vue({
       await this.getThemes()
     }
     await this.getCharges()
-    await this.getWalletConfig()
     await this.getWalletLinks()
     LNbits.api
       .request('GET', '/api/v1/currencies')

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 
 from fastapi import WebSocket
 from lnbits.core.models import Payment
@@ -56,7 +55,7 @@ async def on_invoice_paid(payment: Payment) -> None:
         await send_success_websocket(charge)
         if charge.webhook:
             resp = await call_webhook(charge)
-            charge.extra = json.dumps({**charge.config.dict(), **resp})
+            charge.add_extra(resp)
         await update_charge(charge)
 
 
@@ -111,5 +110,5 @@ async def _handle_ws_message(address: str, data: dict):
         stop_onchain_listener(address)
     if charge.webhook:
         resp = await call_webhook(charge)
-        charge.extra = json.dumps({**charge.config.dict(), **resp})
+        charge.add_extra(resp)
     await update_charge(charge)

--- a/templates/satspay/display.html
+++ b/templates/satspay/display.html
@@ -196,7 +196,7 @@
 {% endblock %} {% block scripts %}
 <script>
   const charge_data = JSON.parse({{ charge_data|tojson }});
-  const network = "{{ network }}";
+  const mempool_url = "{{ mempool_url }}";
 </script>
 <script src="{{ static_url_for('satspay/static', path='js/utils.js') }}"></script>
 <script src="{{ static_url_for('satspay/static', path='js/components.js') }}"></script>

--- a/templates/satspay/index.html
+++ b/templates/satspay/index.html
@@ -618,6 +618,7 @@
 {% endblock %} {% block scripts %} {{ window_vars(user) }}
 <script>
   const admin = '{{ admin }}'
+  const network = '{{ network }}'
 </script>
 <script src="{{ static_url_for('satspay/static', path='js/utils.js') }}"></script>
 <script src="{{ static_url_for('satspay/static', path='js/index.js') }}"></script>

--- a/views.py
+++ b/views.py
@@ -30,9 +30,15 @@ def satspay_renderer():
 
 @satspay_generic_router.get("/", response_class=HTMLResponse)
 async def index(request: Request, user: User = Depends(check_user_exists)):
+    settings = await get_or_create_satspay_settings()
     return satspay_renderer().TemplateResponse(
         "satspay/index.html",
-        {"request": request, "user": user.dict(), "admin": user.admin},
+        {
+            "request": request,
+            "user": user.dict(),
+            "admin": user.admin,
+            "network": settings.network,
+        },
     )
 
 

--- a/views.py
+++ b/views.py
@@ -17,7 +17,7 @@ from lnbits.helpers import template_renderer
 from lnbits.settings import settings
 from starlette.responses import HTMLResponse
 
-from .crud import get_charge, get_theme
+from .crud import get_charge, get_or_create_satspay_settings, get_theme
 from .tasks import public_ws_listeners
 
 templates = Jinja2Templates(directory="templates")
@@ -43,14 +43,14 @@ async def display_charge(request: Request, charge_id: str):
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Charge link does not exist."
         )
+    settings = await get_or_create_satspay_settings()
     return satspay_renderer().TemplateResponse(
         "satspay/display.html",
         {
             "request": request,
             "charge_data": json.dumps(charge.public),
             "custom_css": charge.custom_css,
-            "mempool_endpoint": charge.config.mempool_endpoint,
-            "network": charge.config.network,
+            "mempool_url": settings.mempool_url,
         },
     )
 

--- a/views_api.py
+++ b/views_api.py
@@ -62,18 +62,16 @@ async def api_charges_retrieve(
     return await get_charges(wallet.wallet.user)
 
 
-"""
-This endpoint is used by the woocommerce plugin to check if the status of a charge
-is paid. you can refresh the success page of the webshop to trigger this endpoint.
-useful if the webhook is not working or fails for some reason.
-https://github.com/lnbits/woocommerce-payment-gateway/blob/main/lnbits.php#L312
-"""
-
-
 @satspay_api_router.get(
     "/api/v1/charge/{charge_id}", dependencies=[Depends(require_invoice_key)]
 )
 async def api_charge_retrieve(charge_id: str) -> dict:
+    """
+    This endpoint is used by the woocommerce plugin to check if the status of a charge
+    is paid. you can refresh the success page of the webshop to trigger this endpoint.
+    useful if the webhook is not working or fails for some reason.
+    https://github.com/lnbits/woocommerce-payment-gateway/blob/main/lnbits.php#L312
+    """
     charge = await get_charge(charge_id)
     if not charge:
         raise HTTPException(

--- a/views_api.py
+++ b/views_api.py
@@ -20,7 +20,7 @@ from .crud import (
     update_charge,
     update_satspay_settings,
 )
-from .helpers import check_charge_balance, fetch_onchain_config
+from .helpers import check_charge_balance, fetch_onchain_address
 from .models import Charge, CreateCharge, SatspaySettings
 from .tasks import start_onchain_listener, stop_onchain_listener
 
@@ -41,7 +41,7 @@ async def api_charge_create(
         data.amount = round(rate * data.currency_amount)
     if data.onchainwallet:
         try:
-            config, new_address = await fetch_onchain_config(
+            new_address = await fetch_onchain_address(
                 data.onchainwallet, wallet.wallet.inkey
             )
             start_onchain_listener(new_address)
@@ -49,7 +49,6 @@ async def api_charge_create(
                 user=wallet.wallet.user,
                 onchainaddress=new_address,
                 data=data,
-                config=config,
             )
         except Exception as exc:
             logger.error(f"Error fetching onchain config: {exc}")


### PR DESCRIPTION
- now extra just passes through anything a user provides
- removing the Charge config altogether, now with the single backend listener this config was redundant
- add a check if the selected onchain wallet has the proper network configured in satspay