### PR TITLE
fix: Onchain payment never marked paid once lightning invoice is cleaned up

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -89,11 +89,11 @@ async def check_charge_balance(charge: Charge) -> Charge:
 
     if charge.lnbitswallet and charge.payment_hash:
         payment = await get_standalone_payment(charge.payment_hash)
-        assert payment, "Payment not found."
-        status = await payment.check_status()
-        if status.success:
-            charge.add_extra({"payment_method": "lightning"})
-            charge.balance = charge.amount
+        if payment:
+            status = await payment.check_status()
+            if status.success:
+                charge.add_extra({"payment_method": "lightning"})
+                charge.balance = charge.amount
 
     if charge.onchainaddress:
         try:


### PR DESCRIPTION
Reported here: https://github.com/lnbits/satspay/issues/74

Depends on PR: https://github.com/lnbits/satspay/pull/73 (fix will be merged and released after v1.0 is out)